### PR TITLE
fixing urbanite's frontend start path

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -134,7 +134,7 @@ npm install
 npm run build 
 ```
 
-To start Urbanite's frontend, simply run:
+Now, go to the `frontend/urban-workflows` folder and run the following lines to start Urbanite's frontend:
 
 ```console
 npm install


### PR DESCRIPTION
### Description
The tutorial had an issue when trying to start the frontend for Urbanite since there was no indication of which path we should choose to run the commands.

### Changes
The path was added.

### Impact
Now people will be able to run the commands and start Urbanite's frontend

### Testing
After following the previous steps (1, 2, and first block of code showing on part 3) by going to the `frontend/urban-workflows` you will now be able to run:

```
npm install
npm run build
npm run start
```

and successfully launch the frontend.
